### PR TITLE
Plasma widget icon looks like a warning indication

### DIFF
--- a/package/contents/ui/CompactRepresentation.qml
+++ b/package/contents/ui/CompactRepresentation.qml
@@ -34,6 +34,8 @@ Item {
     property int temperatureIncrement: plasmoid.configuration.manualTemperatureStep
     property int temperatureMin: 1000
     property int temperatureMax: 25000
+
+    property bool textColorLight: ((theme.textColor.r + theme.textColor.g + theme.textColor.b) / 3) > 0.5
     
     Label {
         id: bulbIcon
@@ -42,8 +44,8 @@ Item {
         font.family: 'FontAwesome'
         text: '\uf0eb'
         
-        color: active ? '#FF3300' : theme.textColor
-        font.pointSize: fontPointSize
+        color: active ? theme.textColor : (textColorLight ? Qt.tint(theme.textColor, '#80000000') : Qt.tint(theme.textColor, '#80FFFFFF'))
+        font.pointSize: fontPointSize * 0.8
     }
     
     Label {
@@ -56,7 +58,7 @@ Item {
         font.family: 'FontAwesome'
         text: '\uf04c'
         
-        color: theme.textColor
+        color: textColorLight ? Qt.tint(theme.textColor, '#80FFFF00') : Qt.tint(theme.textColor, '#80FF3300')
         font.pointSize: fontPointSize * 0.3
         
         visible: manualEnabled
@@ -72,6 +74,7 @@ Item {
                 manualTemperature = manualStartingTemperature
                 redshiftDS.connectedSources.length = 0
                 manualEnabled = true
+                active = false
             }
             if (redshiftDS.connectedSources.length > 0) {
                 return


### PR DESCRIPTION
Currently the icon of the plasma widget looks like some warning or error indication (overly big and red) which is somewhat distracting and does not match the style of the rest of the "native" panel icons.

Changes done in this pull request:

 * Widget icon is now in panel color while redshift *is active and not in manual mode*
 * Make the widget icon smaller to make its size similar to other panel widgets
 * Widget icon is now displayed in a grayed out (by ~45%) color tone while redshift is disabled
 * Both the main widget icon and the "manual mode" icon now look good with all standard themes (both light and dark themes tested!)
 * The main widget is now always grayed out while in "manual mode" (since redshift does not do anything in this mode by itself / is disabled)

Let me know what you think!