### PR TITLE
Fix temperature preview for non english locales

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -62,7 +62,7 @@ Item {
     // - commands
     property string redshiftCommand: 'redshift' + locationCmdPart + modeCmdPart + ' -t ' + dayTemperature + ':' + nightTemperature + brightnessAndGamma + (smoothTransitions ? '' : ' -r')
     property string redshiftOneTimeCommand: 'redshift -O ' + manualTemperature + brightnessAndGamma + ' -r'
-    property string redshiftPrintCommand: redshiftCommand + ' -p'
+    property string redshiftPrintCommand: 'LANG=C ' + redshiftCommand + ' -p'
     
     property bool inTray: (plasmoid.parent === null || plasmoid.parent.objectName === 'taskItemContainer')
     


### PR DESCRIPTION
Applet expects english string format of 'Color temperature', but this assumption is valid only for english locales.
Set environment variable LANG=C to force minimal c translation.

Closes #11